### PR TITLE
Add iOS support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ libc = "0.2"
 bitflags = "1.0"
 thiserror = "1"
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 enum-primitive-derive = "0.1.2"
 num-traits = "0.2.8"
 byteorder = "1.3.2"

--- a/src/integrations/mod.rs
+++ b/src/integrations/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(target_os = "linux")]
 mod linux;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 mod osx;
 #[cfg(target_os = "windows")]
 mod windows;
@@ -10,7 +10,7 @@ pub use self::shared_api::*;
 
 #[cfg(target_os = "linux")]
 pub use self::linux::*;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub use self::osx::*;
 #[cfg(target_os = "windows")]
 pub use self::windows::*;


### PR DESCRIPTION
This adds iOS support, it treats iOS targets as macOS (they act the same).

I did the same for [`sysinfo`](https://github.com/GuillaumeGomez/sysinfo/pull/343) crate.