### PR TITLE
Add `iterate_sockets_info_without_pids` to linux

### DIFF
--- a/src/integrations/linux/api.rs
+++ b/src/integrations/linux/api.rs
@@ -9,6 +9,17 @@ pub fn iterate_sockets_info(
     af_flags: AddressFamilyFlags,
     proto_flags: ProtocolFlags,
 ) -> Result<impl Iterator<Item = Result<SocketInfo, Error>>, Error> {
+    Ok(attach_pids(iterate_sockets_info_without_pids(
+        af_flags,
+        proto_flags,
+    )?))
+}
+
+/// Iterate through sockets information without attaching PID.
+pub fn iterate_sockets_info_without_pids(
+    af_flags: AddressFamilyFlags,
+    proto_flags: ProtocolFlags,
+) -> Result<impl Iterator<Item = Result<SocketInfo, Error>>, Error> {
     let ipv4 = af_flags.contains(AddressFamilyFlags::IPV4);
     let ipv6 = af_flags.contains(AddressFamilyFlags::IPV6);
     let tcp = proto_flags.contains(ProtocolFlags::TCP);
@@ -32,7 +43,7 @@ pub fn iterate_sockets_info(
             }
         }
     }
-    Ok(attach_pids(iterators.into_iter().flatten()))
+    Ok(iterators.into_iter().flatten())
 }
 
 fn attach_pids(


### PR DESCRIPTION
Adding this in case PID association is not required. This is not useful on macOS since we always iterate through all PIDs.