### PR TITLE
Improve the build script for `cargo zigbuild` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netstat2"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Ohad Ravid <ohad.rv@gmail.com>", "ivxvm <ivxvm@protonmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/build.rs
+++ b/build.rs
@@ -1,49 +1,59 @@
 use std::env;
 use std::path::Path;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "linux", target_os = "android"))]
 fn main() {
-    let bindings = bindgen::builder()
-        .header_contents("libproc_rs.h", "#include <libproc.h>")
-        .layout_tests(false)
-        .clang_args(&["-x", "c++", "-I", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/"])
-        .generate()
-        .expect("Failed to build libproc bindings");
+    let os = env::var("CARGO_CFG_TARGET_OS").unwrap();
 
-    let output_path = Path::new(&env::var("OUT_DIR")
-        .expect("OUT_DIR env var was not defined"))
-        .join("libproc_bindings.rs");
+    match os.as_str() {
+        "macos" | "ios" => {
+            let bindings = bindgen::builder()
+                .header_contents("libproc_rs.h", "#include <libproc.h>")
+                .layout_tests(false)
+                .clang_args(&[
+                    "-x",
+                    "c++",
+                    "-I",
+                    "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/",
+                ])
+                .generate()
+                .expect("Failed to build libproc bindings");
 
-    bindings
-        .write_to_file(output_path)
-        .expect("Failed to write libproc bindings");
+            let output_path =
+                Path::new(&env::var("OUT_DIR").expect("OUT_DIR env var was not defined"))
+                    .join("libproc_bindings.rs");
+
+            bindings
+                .write_to_file(output_path)
+                .expect("Failed to write libproc bindings");
+        }
+        "linux" | "android" => {
+            let bindings = bindgen::builder()
+                .header_contents(
+                    "linux_bindings.h",
+                    r#"
+                    #include <linux/sock_diag.h>
+                    #include <linux/inet_diag.h>
+                    #include <linux/rtnetlink.h>
+                    #include <linux/netlink.h>
+                    #include <linux/tcp.h>
+                "#,
+                )
+                .layout_tests(false)
+                .generate()
+                .expect("Failed to build linux bindings");
+
+            let output_path =
+                Path::new(&env::var("OUT_DIR").expect("OUT_DIR env var was not defined"))
+                    .join("linux_bindings.rs");
+
+            bindings
+                .write_to_file(output_path)
+                .expect("Failed to write linux bindings");
+        }
+        _ => {}
+    }
 }
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
-fn main() {
-    let bindings = bindgen::builder()
-        .header_contents("linux_bindings.h", r#"
-            #include <linux/sock_diag.h>
-            #include <linux/inet_diag.h>
-            #include <linux/rtnetlink.h>
-            #include <linux/netlink.h>
-            #include <linux/tcp.h>
-        "#)
-        .layout_tests(false)
-        .generate()
-        .expect("Failed to build linux bindings");
-
-    let output_path = Path::new(&env::var("OUT_DIR")
-        .expect("OUT_DIR env var was not defined"))
-        .join("linux_bindings.rs");
-
-    bindings
-        .write_to_file(output_path)
-        .expect("Failed to write linux bindings");
-}
-
-#[cfg(target_os = "windows")]
-fn main() {}
-
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "linux", target_os = "android", target_os = "windows")))]
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "linux", target_os = "android")))]
 fn main() {}


### PR DESCRIPTION
In #13 @kurtbuilds mentioned using `cargo-zigbuild` for cross compilation.

In #17 I switch to using bindgen with a `build.rs` script, which doesn't work correctly when using `cargo-zigbuild`.

This PR fixes that by checking the `CARGO_CFG_TARGET_OS` instead of the usual `cfg(any(target_os = "..."))`